### PR TITLE
Paralelizado del crawler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
+          python-version: "3.11"
           cache: pip
       - run: |
           pip install --upgrade -r "${GITHUB_WORKSPACE}/dev-requirements.txt"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           cache: pip
       - run: |
           pip install --upgrade -r "${GITHUB_WORKSPACE}/dev-requirements.txt"
+          pip install --upgrade -r "${GITHUB_WORKSPACE}/requirements.txt"
           mypy "src"
           flake8 "src" --ignore=E501,W503,E203,E402
           black "src" --check -l 80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 beautifulsoup4
 nltk
-asyncio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 beautifulsoup4
 nltk
+asyncio

--- a/src/crawler/app.py
+++ b/src/crawler/app.py
@@ -1,3 +1,5 @@
+import asyncio
+import multiprocessing
 from argparse import ArgumentParser
 
 from .crawler import Crawler
@@ -35,10 +37,19 @@ def parse_args():
         help="Carpeta destino donde almacenar el contenido"
         " de las URLs crawleadas.",
     )
+
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=multiprocessing.cpu_count(),
+        help="Cantidad de consultas concurrentes",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
     crawler = Crawler(args)
-    crawler.crawl()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(crawler.crawl())


### PR DESCRIPTION
La paralelización se realiza a través de la librería asyncio. Las consultas de páginas se delegan a corutinas ejecutadas en paralelo y los resultados se unifican una vez que cada grupo de tareas es completada.

Se agrego también el parámetro `--jobs` para controlar cuántas peticiones concurrentes se realizan, por defecto utiliza el número de núcleos disponible en el sistema.