### PR TITLE
Agregar soporte para paréntesis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - run: |
           pip install --upgrade -r "${GITHUB_WORKSPACE}/dev-requirements.txt"
           autoflake --remove-all-unused-imports --recursive --remove-unused-variables "src"
-          isort --check "src"
+          isort -m3 -tc --check "src"
 
   lint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
   rev: 5.11.5
   hooks:
     - id: isort
+      args: [-m3, -tc]
 - repo: https://github.com/psf/black
   rev: '23.11.0'
   hooks:

--- a/dev-tools/format.sh
+++ b/dev-tools/format.sh
@@ -2,5 +2,5 @@
 set -x
 
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place "src"
-isort "src"
+isort -m3 -tc "src"
 black "src" -l 80

--- a/src/retriever/ast.py
+++ b/src/retriever/ast.py
@@ -1,30 +1,42 @@
 from abc import ABC, abstractmethod
+from typing import List
+
+from ..indexer.indexer import Index  # type: ignore
 
 
-class Node(ABC):
+class AstNode(ABC):
+    """Representación de un nodo del AST"""
+
     @abstractmethod
-    def eval(self, index):
+    def eval(self, index: Index) -> List[int]:
+        """Evalúa el nodo utilizando el índice provisto
+
+        Args:
+            index (Index): Índice utilizado en la evaluación del AST
+        Returns:
+            List[Result]: lista de resultados que cumplen la consulta
+        """
         ...
 
 
-class AndNode(Node):
-    def __init__(self, left, right):
+class AndNode(AstNode):
+    def __init__(self, left: AstNode, right: AstNode):
         self.left = left
         self.right = right
 
-    def eval(self, index):
+    def eval(self, index: Index) -> List[int]:
         return list(set(self.left.eval(index)) & set(self.right.eval(index)))
 
     def __str__(self):
         return f"({self.left} AND {self.right})"
 
 
-class OrNode(Node):
+class OrNode(AstNode):
     def __init__(self, left, right):
         self.left = left
         self.right = right
 
-    def eval(self, index):
+    def eval(self, index: Index) -> List[int]:
         return list(
             sorted(set(self.left.eval(index)) | set(self.right.eval(index)))
         )
@@ -33,23 +45,23 @@ class OrNode(Node):
         return f"({self.left} OR {self.right})"
 
 
-class NotNode(Node):
+class NotNode(AstNode):
     def __init__(self, data):
         self.data = data
 
-    def eval(self, index):
-        all_docs: set = set(index.ids_all_docs)
+    def eval(self, index: Index) -> List[int]:
+        all_docs: set = set(doc.id for doc in index.documents)
         return list(all_docs - set(self.data.eval(index)))
 
     def __str__(self):
-        return f"NOT ({self.data})"
+        return f"NOT {self.data}"
 
 
-class WordNode(Node):
+class WordNode(AstNode):
     def __init__(self, data):
         self.data = data
 
-    def eval(self, index):
+    def eval(self, index: Index) -> List[int]:
         return index.postings[self.data]
 
     def __str__(self):

--- a/src/retriever/ast.py
+++ b/src/retriever/ast.py
@@ -1,0 +1,56 @@
+from abc import ABC, abstractmethod
+
+
+class Node(ABC):
+    @abstractmethod
+    def eval(self, index):
+        ...
+
+
+class AndNode(Node):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def eval(self, index):
+        return list(set(self.left.eval(index)) & set(self.right.eval(index)))
+
+    def __str__(self):
+        return f"({self.left} AND {self.right})"
+
+
+class OrNode(Node):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def eval(self, index):
+        return list(
+            sorted(set(self.left.eval(index)) | set(self.right.eval(index)))
+        )
+
+    def __str__(self):
+        return f"({self.left} OR {self.right})"
+
+
+class NotNode(Node):
+    def __init__(self, data):
+        self.data = data
+
+    def eval(self, index):
+        all_docs: set = set(index.ids_all_docs)
+        return list(all_docs - set(self.data.eval(index)))
+
+    def __str__(self):
+        return f"NOT ({self.data})"
+
+
+class WordNode(Node):
+    def __init__(self, data):
+        self.data = data
+
+    def eval(self, index):
+        return index.postings[self.data]
+
+    def __str__(self):
+        return self.data

--- a/src/retriever/lexer.py
+++ b/src/retriever/lexer.py
@@ -38,6 +38,7 @@ class Lexer:
         self.next_token()
 
     def _eat_whitespace(self):
+        """Método que elimina espacios en blanco de la query procesada."""
         while (
             self.index < len(self.query)
             and self.query[self.index] in _ignorable_whitespace
@@ -45,6 +46,7 @@ class Lexer:
             self.index += 1
 
     def next_token(self):
+        """Mueve el lexer al próximo token."""
         self._eat_whitespace()
 
         if self.index >= len(self.query):
@@ -61,14 +63,15 @@ class Lexer:
             self.cur_token = RParenToken
             return
 
-        token = ""
+        offset = 0
         while (
-            self.index < len(self.query)
-            and self.query[self.index] not in _delimiters
+            self.index + offset < len(self.query)
+            and self.query[self.index + offset] not in _delimiters
         ):
-            token += self.query[self.index]
-            self.index += 1
+            offset += 1
 
+        token = self.query[self.index : self.index + offset]
+        self.index += offset
         if token == "AND":
             self.cur_token = AndToken
         elif token == "OR":

--- a/src/retriever/lexer.py
+++ b/src/retriever/lexer.py
@@ -29,6 +29,8 @@ class Lexer:
     def __init__(self, query):
         self.query = query
         self.index = 0
+        self.cur_token = None
+        self.next_token()
 
     def _eat_whitespace(self):
         while (
@@ -41,7 +43,8 @@ class Lexer:
         self._eat_whitespace()
 
         if self.index >= len(self.query):
-            return DoneToken
+            self.cur_token = DoneToken
+            return
 
         token = ""
         while (
@@ -52,9 +55,10 @@ class Lexer:
             self.index += 1
 
         if token == "AND":
-            return AndToken
-        if token == "OR":
-            return OrToken
-        if token == "NOT":
-            return NotToken
-        return Token(WORD, token)
+            self.cur_token = AndToken
+        elif token == "OR":
+            self.cur_token = OrToken
+        elif token == "NOT":
+            self.cur_token = NotToken
+        else:
+            self.cur_token = Token(WORD, token)

--- a/src/retriever/lexer.py
+++ b/src/retriever/lexer.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+WORD = 0
+AND = 1
+OR = 2
+NOT = 3
+DONE = 4
+
+_ignorable_whitespace = " \t"
+
+
+@dataclass
+class Token:
+    """Clase que representa un token leído por el lexer"""
+
+    type: int
+    value: str
+
+
+AndToken = Token(AND, "AND")
+OrToken = Token(OR, "OR")
+NotToken = Token(NOT, "NOT")
+DoneToken = Token(DONE, "")
+
+
+class Lexer:
+    """Lexer encargado de leer queries y traducirlas a tokens"""
+
+    def __init__(self, query):
+        self.query = query
+        self.index = 0
+
+    def _eat_whitespace(self):
+        while (
+            self.index < len(self.query)
+            and self.query[self.index] in _ignorable_whitespace
+        ):
+            self.index += 1
+
+    def next_token(self):
+        self._eat_whitespace()
+
+        if self.index >= len(self.query):
+            return DoneToken
+
+        token = ""
+        while (
+            self.index < len(self.query)
+            and self.query[self.index] not in _ignorable_whitespace
+        ):
+            token += self.query[self.index]
+            self.index += 1
+
+        if token == "AND":
+            return AndToken
+        if token == "OR":
+            return OrToken
+        if token == "NOT":
+            return NotToken
+        return Token(WORD, token)

--- a/src/retriever/lexer.py
+++ b/src/retriever/lexer.py
@@ -31,10 +31,11 @@ RParenToken = Token(RPAREN, ")")
 class Lexer:
     """Lexer encargado de leer queries y traducirlas a tokens"""
 
-    def __init__(self, query):
+    def __init__(self, query: str):
         self.query = query
         self.index = 0
-        self.cur_token = None
+        # Asignado a DoneToken para que el linter sea feliz
+        self.cur_token = DoneToken
         self.next_token()
 
     def _eat_whitespace(self):

--- a/src/retriever/lexer.py
+++ b/src/retriever/lexer.py
@@ -4,9 +4,12 @@ WORD = 0
 AND = 1
 OR = 2
 NOT = 3
-DONE = 4
+LPAREN = 4
+RPAREN = 5
+DONE = 6
 
 _ignorable_whitespace = " \t"
+_delimiters = _ignorable_whitespace + "()"
 
 
 @dataclass
@@ -21,6 +24,8 @@ AndToken = Token(AND, "AND")
 OrToken = Token(OR, "OR")
 NotToken = Token(NOT, "NOT")
 DoneToken = Token(DONE, "")
+LParenToken = Token(LPAREN, "(")
+RParenToken = Token(RPAREN, ")")
 
 
 class Lexer:
@@ -46,10 +51,20 @@ class Lexer:
             self.cur_token = DoneToken
             return
 
+        if self.query[self.index] == "(":
+            self.index += 1
+            self.cur_token = LParenToken
+            return
+
+        if self.query[self.index] == ")":
+            self.index += 1
+            self.cur_token = RParenToken
+            return
+
         token = ""
         while (
             self.index < len(self.query)
-            and self.query[self.index] not in _ignorable_whitespace
+            and self.query[self.index] not in _delimiters
         ):
             token += self.query[self.index]
             self.index += 1

--- a/src/retriever/parser.py
+++ b/src/retriever/parser.py
@@ -1,5 +1,4 @@
-from abc import ABC, abstractmethod
-
+from .ast import AndNode, NotNode, OrNode, WordNode
 from .lexer import (
     WORD,
     AndToken,
@@ -10,61 +9,6 @@ from .lexer import (
     OrToken,
     RParenToken,
 )
-
-
-class Node(ABC):
-    @abstractmethod
-    def eval(self, index):
-        ...
-
-
-class AndNode(Node):
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
-
-    def eval(self, index):
-        return list(set(self.left.eval(index)) & set(self.right.eval(index)))
-
-    def __str__(self):
-        return f"({self.left} AND {self.right})"
-
-
-class OrNode(Node):
-    def __init__(self, left, right):
-        self.left = left
-        self.right = right
-
-    def eval(self, index):
-        return list(
-            sorted(set(self.left.eval(index)) | set(self.right.eval(index)))
-        )
-
-    def __str__(self):
-        return f"({self.left} OR {self.right})"
-
-
-class NotNode(Node):
-    def __init__(self, data):
-        self.data = data
-
-    def eval(self, index):
-        all_docs: set = set(index.ids_all_docs)
-        return list(all_docs - set(self.data.eval(index)))
-
-    def __str__(self):
-        return f"NOT ({self.data})"
-
-
-class WordNode(Node):
-    def __init__(self, data):
-        self.data = data
-
-    def eval(self, index):
-        return index.postings[self.data]
-
-    def __str__(self):
-        return self.data
 
 
 class InvalidQueryException(Exception):

--- a/src/retriever/parser.py
+++ b/src/retriever/parser.py
@@ -1,0 +1,109 @@
+from abc import ABC, abstractmethod
+
+from .lexer import WORD, AndToken, DoneToken, Lexer, NotToken, OrToken
+
+
+class Node(ABC):
+    @abstractmethod
+    def eval(self, index):
+        ...
+
+
+class AndNode(Node):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def eval(self, index):
+        return list(set(self.left.eval(index)) & set(self.right.eval(index)))
+
+
+class OrNode(Node):
+    def __init__(self, left, right):
+        self.left = left
+        self.right = right
+
+    def eval(self, index):
+        return list(
+            sorted(set(self.left.eval(index)) | set(self.right.eval(index)))
+        )
+
+
+class NotNode(Node):
+    def __init__(self, data):
+        self.data = data
+
+    def eval(self, index):
+        all_docs: set = set(index.ids_all_docs)
+        return list(all_docs - set(self.data.eval(index)))
+
+
+class WordNode(Node):
+    def __init__(self, data):
+        self.data = data
+
+    def eval(self, index):
+        return index.postings[self.data]
+
+
+class InvalidQueryException(Exception):
+    def __init__(self, message):
+        super.__init__(f"Invalid query: {message}")
+
+
+class Parser:
+    def __init__(self, query):
+        self.lexer = Lexer(query)
+
+    def _parse_not_node(self):
+        token = self.lexer.cur_token
+        if token.type != WORD:
+            raise InvalidQueryException(f"Expected WORD, got {token.value}")
+
+        return NotNode(WordNode(token.value))
+
+    def _parse_infix_operation(self, operator, left):
+        right = self.lexer.cur_token
+
+        if right == NotToken:
+            right = self._parse_not_node()
+        elif right.type == WORD:
+            right = WordNode(right.value)
+        else:
+            raise InvalidQueryException(
+                f"Expected WORD or NOT, got {right.value}"
+            )
+
+        if operator == AndToken:
+            return AndNode(left, right)
+        elif operator == OrToken:
+            return OrNode(left, right)
+        raise InvalidQueryException(f"Expected AND or OR, got {operator.value}")
+
+    def _parse(self, left):
+        token = self.lexer.cur_token
+
+        if left is None:
+            if token == NotToken:
+                self.lexer.next_token()
+                return self._parse_not_node()
+            elif token.type == WORD:
+                return WordNode(token.value)
+            else:
+                raise InvalidQueryException(
+                    f"Expected NOT or WORD, got {token.value}"
+                )
+
+        self.lexer.next_token()
+        return self._parse_infix_operation(token, left)
+
+    def parse(self):
+        tree = None
+        import pdb
+
+        pdb.set_trace()
+        while self.lexer.cur_token != DoneToken:
+            tree = self._parse(tree)
+            self.lexer.next_token()
+
+        return tree

--- a/src/retriever/retriever.py
+++ b/src/retriever/retriever.py
@@ -48,7 +48,8 @@ class Retriever:
         """
         parser = Parser(query)
         ast = parser.parse()
-        return ast.eval(self.index)
+        ast.eval(self.index)
+        return []
 
     def search_from_file(self, fname: str) -> Dict[str, List[Result]]:
         """Método para hacer consultas desde fichero.
@@ -75,44 +76,3 @@ class Retriever:
         """Método para cargar un índice invertido desde disco."""
         with open(self.args.index_file, "rb") as fr:
             return pkl.load(fr)
-
-    def _and_(self, posting_a: List[int], posting_b: List[int]) -> List[int]:
-        """Método para calcular la intersección de dos posting lists.
-        Será necesario para resolver queries que incluyan "A AND B"
-        en `search_query`.
-
-        Args:
-            posting_a (List[int]): una posting list
-            posting_b (List[int]): otra posting list
-        Returns:
-            List[int]: posting list de la intersección
-        """
-        ...
-        return []
-
-    def _or_(self, posting_a: List[int], posting_b: List[int]) -> List[int]:
-        """Método para calcular la unión de dos posting lists.
-        Será necesario para resolver queries que incluyan "A OR B"
-        en `search_query`.
-
-        Args:
-            posting_a (List[int]): una posting list
-            posting_b (List[int]): otra posting list
-        Returns:
-            List[int]: posting list de la unión
-        """
-        ...
-        return []
-
-    def _not_(self, posting_a: List[int]) -> List[int]:
-        """Método para calcular el complementario de una posting list.
-        Será necesario para resolver queries que incluyan "NOT A"
-        en `search_query`
-
-        Args:
-            posting_a (List[int]): una posting list
-        Returns:
-            List[int]: complementario de la posting list
-        """
-        ...
-        return []


### PR DESCRIPTION
Se agrega soporte para paréntesis al retriever. Para poder dar un soporte correcto a esta funcionalidad, se agregaron un módulo lexer y un parser.

El lexer es una forma más sofisticada de tokenizar que el inicial `split()`. Este módulo lee de a un caracter y generar tokens con un poco más de información, gracias a esto deberíamos poder soportar paréntesis en cualquier parte de la query. Ejemplos:
- NOT empresa AND (universidad OR colegio)
- NOT empresa AND ( universidad OR colegio )
- NOT empresa AND(universidad OR colegio)

El parser se encarga de tomar los tokens generados por el lexer y genera un árbol abstracto de sintáxis, utilizando clases con un método `eval` que toma el índice generado por la etapa anterior de procesamiento. Esto da una separación de resposabilidades y simplifica el código del retriever, que ahora sólo debe crear el parser, ejecutarlo para obtener el árbol y finalmente evaluar el mismo.