### PR TITLE
Convertir lista de índices a resultados y mostrarlos en pantalla

### DIFF
--- a/src/retriever/app.py
+++ b/src/retriever/app.py
@@ -49,6 +49,10 @@ if __name__ == "__main__":
     args = parse_args()
     retriever = Retriever(args)
     if args.query:
-        retriever.search_query(args.query)
+        for res in retriever.search_query(args.query):
+            print(res)
     elif args.file:
-        retriever.search_from_file(args.file)
+        for query, results in retriever.search_from_file(args.file).items():
+            print(f"#### {query} ####")
+            for res in results:
+                print(res)

--- a/src/retriever/retriever.py
+++ b/src/retriever/retriever.py
@@ -48,8 +48,12 @@ class Retriever:
         """
         parser = Parser(query)
         ast = parser.parse()
-        ast.eval(self.index)
-        return []
+
+        return [self.int_to_result(index) for index in ast.eval(self.index)]
+
+    def int_to_result(self, index: int) -> Result:
+        res = self.index.documents[index]
+        return Result(url=res.url, snippet=res.snippet)
 
     def search_from_file(self, fname: str) -> Dict[str, List[Result]]:
         """Método para hacer consultas desde fichero.


### PR DESCRIPTION
Estos cambios modifican el retriever para que search_query devuelva la lista de resultados final. También se modificó ligeramente el indexer para agregar un snippet de texto para al índice, se cambió el campo title para que tome el tag <title> de la página y se corrigieron algunos bugs menores.