### PR TITLE
Corrección retriever para que devuelva resultados acotados

### DIFF
--- a/src/retriever/app.py
+++ b/src/retriever/app.py
@@ -36,7 +36,6 @@ def parse_args():
         type=int,
         default=10,
         help="Número de resultados",
-        required=True,
     )
 
     # Añade aquí cualquier otro argumento que condicione

--- a/src/retriever/retriever.py
+++ b/src/retriever/retriever.py
@@ -56,7 +56,7 @@ class Retriever:
         ]
         res.sort(key=lambda x: x.score, reverse=True)
 
-        return self.args.max_resultados
+        return res[: self.args.max_resultados]
 
     def int_to_result(self, index: int, terms: List[str]) -> Result:
         res = self.index.documents[index]


### PR DESCRIPTION
Previo a este cambio el retriever estaba devolviendo el número configurado en lugar de la lista de resultados acotados al número. También se quitó el requisito del nuevo parámetro, ya que tiene un valor por defecto.